### PR TITLE
[vhost::proxy] Fix template configuration (proxyfy)

### DIFF
--- a/templates/nginx/vhost_proxy.erb
+++ b/templates/nginx/vhost_proxy.erb
@@ -39,8 +39,7 @@ server {
 
   location / {
     proxy_pass http<%= @to_https ? 's' : '' %>://<%= @to_domainval %>:<%= @to_portval %>/;
-    proxy_redirect          off;
-    # proxy_set_header        Host            $host;
+    proxy_set_header        Host            $host;
     proxy_set_header        X-Real-IP       $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_connect_timeout   90;


### PR DESCRIPTION
=> Set proxy_redirect to his default value (default).
The default replacement specified by the default parameter uses the
parameters of the location and proxy_pass directives. (The default
parameter is not permitted if proxy_pass is specified using variables)
This not our case =)

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect

And add a Host header to proxyfy
