### PR TITLE
php::cgi: Fix deprecate variable notation in inline template

### DIFF
--- a/manifests/php/cgi.pp
+++ b/manifests/php/cgi.pp
@@ -170,8 +170,8 @@ class nginxpack::php::cgi (
       path    => "/etc/php5/${php_confdir}/php.ini",
       match   => 'post_max_size',
       line    => inline_template('post_max_size = <%= \
-        (upload_max_files.to_i * upload_max_filesize[0..-2].to_i).to_s\
-        + upload_max_filesize[-1] %>'),
+        (@upload_max_files.to_i * @upload_max_filesize[0..-2].to_i).to_s\
+        + @upload_max_filesize[-1] %>'),
       require => Package[$php_package],
       notify  => Service[$php_service],
     }


### PR DESCRIPTION
``` puppet
Debug: template[inline]: Bound template variables for inline template in 0.00 seconds
Warning: Variable access via 'upload_max_files' is deprecated. Use '@upload_max_files' instead. template[inline]:2
   (at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:76:in `method_missing')
Debug: template[inline]: Interpolated template inline template in 0.00 seconds
```
